### PR TITLE
fix(fzf-lua): don't override user's config

### DIFF
--- a/lua/codecompanion/_extensions/history/pickers/fzf-lua.lua
+++ b/lua/codecompanion/_extensions/history/pickers/fzf-lua.lua
@@ -36,7 +36,6 @@ function FzfluaPicker:browse(current_save_id)
         vim.iter(self.chats):map(format):each(fzf_cb)
         fzf_cb(nil)
     end, {
-        profile = "hide",
         fzf_opts = { ["--with-nth"] = "2..", ["--delimiter"] = string.format("[%s]", nbsp) },
         winopts = { title = "Saved Chats" },
         actions = {


### PR DESCRIPTION
## Description

Fix https://github.com/ravitemer/codecompanion-history.nvim/pull/13#issuecomment-2884177337.

This option overrides user's config unexpectedly.

I add this previously because fzf-lua regarding this as better default. User can still enable it in fzf-lua's config.
```lua
require('fzf-lua').setup({ 'hide' })
```
