### PR TITLE
fix(fzf-lua): send correct obj to `on_delete`

### DIFF
--- a/lua/codecompanion/_extensions/history/pickers/fzf-lua.lua
+++ b/lua/codecompanion/_extensions/history/pickers/fzf-lua.lua
@@ -83,7 +83,7 @@ function FzfluaPicker:browse(current_save_id)
                 end
                 -- Delete all selected items
                 for _, selection in ipairs(selections) do
-                    self.handlers.on_delete(decode(selection).value)
+                    self.handlers.on_delete(decode(selection))
                 end
                 self.handlers.on_open()
             end,


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->
```lua
on_delete: fun(chat_data: ChatData)
```
`on_delete` should recive an `chatdata`, not `chatdata.value`.
cc @phanen 


## Checklist

- [x] I've read the [contributing](https://github.com/ravitemer/codecompanion-history.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make test` to ensure all tests pass
- [ ] I've run `make format` to format the code
- [ ] I've run `make docs` to update the vimdoc pages


## Related

there are also some issues in snacks.picker about key-binding(delete_history), but i have no idea with it, when i have time, i' ll try to find it out :)

---
thanks for this amazing plugins!
