### PR TITLE
feat: allow refreshing title as the conversation grows (fixes #25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ require("codecompanion").setup({
                     adapter = nil, -- "copilot"
                     ---Model for generating titles (defaults to current chat model)
                     model = nil, -- "gpt-4o"
+                    ---Number of user prompts after which to refresh the title (0 to disable)
+                    refresh_every_n_prompts = 0, -- e.g., 3 to refresh after every 3rd user prompt
+                    ---Maximum number of times to refresh the title (default: 3)
+                    max_refreshes = 3,
                 },
                 ---On exiting and entering neovim, loads the last chat on opening chat
                 continue_last_chat = false,
@@ -121,6 +125,7 @@ require("codecompanion").setup({
 #### 🎯 Commands
 
 - `:CodeCompanionHistory` - Open the history browser
+
 
 #### ⌨️ Chat Buffer Keymaps
 
@@ -144,6 +149,24 @@ Actions in history browser:
   - `<M-r>` (Alt+r) - Rename selected chat
 
 > Note: Delete and rename actions are only available in telescope and snacks pickers. Multiple chats can be selected for deletion using picker's multi-select feature (press `<Tab>`).
+
+#### 🔄 Title Refresh Feature
+
+The extension can automatically refresh chat titles as conversations evolve:
+
+- **`refresh_every_n_prompts`**: Set to refresh the title after every N user prompts (e.g., 3 means refresh after the 3rd, 6th, 9th user message)
+- **`max_refreshes`**: Limits how many times a title can be refreshed to avoid excessive API calls
+- When refreshing, the system considers recent conversation context (both user and assistant messages) and the original title
+- Individual messages are truncated at 1000 characters with a `[truncated]` indicator
+- Total conversation context is limited to 10,000 characters with a `[conversation truncated]` indicator
+
+Example configuration for title refresh:
+```lua
+title_generation_opts = {
+    refresh_every_n_prompts = 3, -- Refresh after every 3rd user prompt
+    max_refreshes = 10,           -- Allow up to 10 refreshes per chat
+}
+```
 
 #### 🔧 API
 
@@ -314,7 +337,4 @@ Special thanks to [Oli Morris](https://github.com/olimorris) for creating the am
 ## 📄 License
 
 MIT
-
-
-
 

--- a/lua/codecompanion/_extensions/history/init.lua
+++ b/lua/codecompanion/_extensions/history/init.lua
@@ -43,6 +43,10 @@ local default_opts = {
         adapter = nil,
         ---Model for generating titles (defaults to current chat model)
         model = nil,
+        ---Number of user prompts after which to refresh the title (0 to disable)
+        refresh_every_n_prompts = 0,
+        ---Maximum number of times to refresh the title (default: 3)
+        max_refreshes = 3,
     },
     ---On exiting and entering neovim, loads the last chat on opening chat
     continue_last_chat = false,
@@ -170,27 +174,35 @@ function History:_setup_autocommands()
             if not chat then
                 return
             end
-            if self.opts.auto_generate_title and not chat.opts.title then
-                log:debug("Attempting to generate title for chat: %s", chat.opts.save_id)
+
+            -- Handle title generation/refresh
+            local should_generate, is_refresh = self.title_generator:should_generate(chat)
+            if should_generate then
                 self.title_generator:generate(chat, function(generated_title)
                     if generated_title and generated_title ~= "" then
-                        log:trace("Setting generated title: %s", generated_title)
+                        -- Always update buffer title for feedback
                         self.ui:_set_buf_title(chat.bufnr, generated_title)
-                        if generated_title == "Deciding title..." then
-                            return
-                        end
-                        chat.opts.title = generated_title
-                        --save the title to history
-                        if self.opts.auto_save then
-                            self.storage:save_chat(chat)
+
+                        -- Only update chat.opts.title and save for real titles (not feedback)
+                        if generated_title ~= "Deciding title..." and generated_title ~= "Refreshing title..." then
+                            if is_refresh then
+                                chat.opts.title_refresh_count = (chat.opts.title_refresh_count or 0) + 1
+                            end
+
+                            chat.opts.title = generated_title
+
+                            if self.opts.auto_save then
+                                self.storage:save_chat(chat)
+                            end
                         end
                     else
-                        local title = self:_get_title(chat)
-                        log:trace("Using default title: %s", title)
-                        self.ui:_set_buf_title(chat.bufnr, title)
+                        -- Fallback to default title when generation fails
+                        local default_title = self:_get_title(chat)
+                        self.ui:_set_buf_title(chat.bufnr, default_title)
                     end
-                end)
+                end, is_refresh)
             end
+
             if self.opts.auto_save then
                 self.storage:save_chat(chat)
             end

--- a/lua/codecompanion/_extensions/history/storage.lua
+++ b/lua/codecompanion/_extensions/history/storage.lua
@@ -337,6 +337,7 @@ function Storage:save_chat(chat)
         schemas = (chat.tools and chat.tools.schemas) or {},
         in_use = (chat.tools and chat.tools.in_use) or {},
         cycle = chat.cycle or 1,
+        title_refresh_count = chat.opts.title_refresh_count or 0,
     }
 
     -- Save chat to file

--- a/lua/codecompanion/_extensions/history/types.lua
+++ b/lua/codecompanion/_extensions/history/types.lua
@@ -9,6 +9,8 @@
 ---@class GenOpts
 ---@field adapter? string? The adapter to use for generation
 ---@field model? string? The model of the adapter to use for generation
+---@field refresh_every_n_prompts? number Number of user prompts after which to refresh the title (0 to disable)
+---@field max_refreshes? number Maximum number of times to refresh the title (default: 3)
 
 ---@class HistoryOpts
 ---@field default_buf_title? string A name for the chat buffer that tells that this is an auto saving chat
@@ -25,7 +27,7 @@
 ---@field picker_keymaps? {rename?: table, delete?: table}
 
 ---@class Chat
----@field opts {title:string, save_id: string}
+---@field opts {title:string, title_refresh_count?: number, save_id: string}
 ---@field messages ChatMessage[]
 ---@field id number
 ---@field bufnr number
@@ -56,6 +58,7 @@
 ---@field in_use? table
 ---@field name? string
 ---@field cycle number
+---@field title_refresh_count? number
 ---
 
 ---@class ChatIndexData

--- a/lua/codecompanion/_extensions/history/ui.lua
+++ b/lua/codecompanion/_extensions/history/ui.lua
@@ -309,6 +309,7 @@ function UI:create_chat(chat_data)
         chat.tools.schemas = chat_data.schemas or {}
         chat.tools.in_use = chat_data.in_use or {}
         chat.cycle = chat_data.cycle or 1
+        chat.opts.title_refresh_count = chat_data.title_refresh_count or 0
         log:trace("Successfully created chat with save_id: %s", save_id or "N/A")
         return chat
     end

--- a/tests/test_title_generator.lua
+++ b/tests/test_title_generator.lua
@@ -108,7 +108,6 @@ T["Title Generation"]["handles empty user message"] = function()
     local result = child.lua([[              
         local title_sequence = {}
         local completed = false
-        local generated_title = nil
 
         -- Mock chat with empty message
         local chat = {
@@ -124,24 +123,20 @@ T["Title Generation"]["handles empty user message"] = function()
         -- Generate title
         test_title_gen:generate(chat, function(title)
             table.insert(title_sequence, tostring(title))
-            if title ~= "Deciding title..." then
-                completed = true
-            end
+            completed = true
         end)
 
         -- Wait for completion
-        vim.wait(1000, function() return completed end)
+        vim.wait(100, function() return completed end)
 
         return {
             first_title = title_sequence[1],
-            final_title = title_sequence[#title_sequence],
             completed = completed,
             prompt_called = test_title_gen.last_prompt ~= nil
         }
     ]])
 
-    eq("Deciding title...", result.first_title)
-    eq("nil", result.final_title) -- Should return nil for empty messages
+    eq("nil", result.first_title) -- Should return nil immediately for empty messages
     eq(true, result.completed)
     eq(false, result.prompt_called) -- Should not even call the adapter
 end
@@ -536,23 +531,19 @@ T["Edge Cases"]["handles nil messages table"] = function()
         -- Generate title
         test_title_gen:generate(chat, function(title)
             table.insert(title_sequence, tostring(title))
-            if title ~= "Deciding title..." then
-                completed = true
-            end
+            completed = true
         end)
 
         vim.wait(100)
 
         return {
             completed = completed,
-            first_title = title_sequence[1],
-            final_title = title_sequence[2] or nil
+            first_title = title_sequence[1]
         }
     ]])
 
     eq(true, result.completed)
-    eq("Deciding title...", result.first_title)
-    eq("nil", result.final_title)
+    eq("nil", result.first_title) -- Should return nil immediately for nil messages
 end
 
 T["Edge Cases"]["handles chat with no user messages"] = function()
@@ -578,9 +569,7 @@ T["Edge Cases"]["handles chat with no user messages"] = function()
         -- Generate title
         test_title_gen:generate(chat, function(title)
             table.insert(title_sequence, tostring(title))
-            if title ~= "Deciding title..." then
-                completed = true
-            end
+            completed = true
         end)
 
         vim.wait(100)
@@ -588,14 +577,12 @@ T["Edge Cases"]["handles chat with no user messages"] = function()
         return {
             completed = completed,
             first_title = title_sequence[1],
-            final_title = title_sequence[2] or nil,
             prompt_called = test_title_gen.last_prompt ~= nil
         }
     ]])
 
     eq(true, result.completed)
-    eq("Deciding title...", result.first_title)
-    eq("nil", result.final_title)
+    eq("Deciding title...", result.first_title) -- Should return nil immediately for no user messages
     eq(false, result.prompt_called)
 end
 
@@ -618,9 +605,7 @@ T["Edge Cases"]["handles nil message content"] = function()
         -- Generate title
         test_title_gen:generate(chat, function(title)
             table.insert(title_sequence, tostring(title))
-            if title ~= "Deciding title..." then
-                completed = true
-            end
+            completed = true
         end)
 
         vim.wait(100)
@@ -628,15 +613,260 @@ T["Edge Cases"]["handles nil message content"] = function()
         return {
             completed = completed,
             first_title = title_sequence[1],
-            final_title = title_sequence[2] or nil,
             prompt_called = test_title_gen.last_prompt ~= nil
         }
     ]])
 
     eq(true, result.completed)
-    eq("Deciding title...", result.first_title)
-    eq("nil", result.final_title)
+    eq("nil", result.first_title) -- Should return nil immediately for nil content
     eq(false, result.prompt_called)
+end
+
+-- Title Refresh Tests
+T["Title Refresh"] = new_set()
+
+T["Title Refresh"]["should_generate returns false when auto_generate_title disabled"] = function()
+    local result = child.lua([[              
+        local TitleGenerator = require("codecompanion._extensions.history.title_generator")
+        local disabled_gen = TitleGenerator.new({
+            auto_generate_title = false
+        })
+
+        local chat = {
+            opts = {},
+            messages = {
+                { role = "user", content = "Test message" }
+            }
+        }
+
+        local should_generate, is_refresh = disabled_gen:should_generate(chat)
+        return { should_generate = should_generate, is_refresh = is_refresh }
+    ]])
+
+    eq(false, result.should_generate)
+    eq(false, result.is_refresh)
+end
+
+T["Title Refresh"]["should_generate returns true for new chat without title"] = function()
+    local result = child.lua([[              
+        local chat = {
+            opts = {},
+            messages = {
+                { role = "user", content = "Test message" }
+            }
+        }
+
+        local should_generate, is_refresh = test_title_gen:should_generate(chat)
+        return { should_generate = should_generate, is_refresh = is_refresh }
+    ]])
+
+    eq(true, result.should_generate)
+    eq(false, result.is_refresh)
+end
+
+T["Title Refresh"]["should_generate returns false for existing title without refresh config"] = function()
+    local result = child.lua([[              
+        local chat = {
+            opts = { title = "Existing Title" },
+            messages = {
+                { role = "user", content = "Test message" }
+            }
+        }
+
+        local should_generate, is_refresh = test_title_gen:should_generate(chat)
+        return { should_generate = should_generate, is_refresh = is_refresh }
+    ]])
+
+    eq(false, result.should_generate)
+    eq(false, result.is_refresh)
+end
+
+T["Title Refresh"]["should_generate returns true when refresh conditions met"] = function()
+    local result = child.lua([[              
+        local TitleGenerator = require("codecompanion._extensions.history.title_generator")
+        local refresh_gen = TitleGenerator.new({
+            auto_generate_title = true,
+            title_generation_opts = {
+                refresh_every_n_prompts = 3,
+                max_refreshes = 2
+            }
+        })
+
+        local chat = {
+            opts = { 
+                title = "Existing Title",
+                title_refresh_count = 0
+            },
+            messages = {
+                { role = "user", content = "Message 1" },
+                { role = "llm", content = "Response 1" },
+                { role = "user", content = "Message 2" },
+                { role = "llm", content = "Response 2" },
+                { role = "user", content = "Message 3" } -- This is the 3rd user message
+            }
+        }
+
+        local should_generate, is_refresh = refresh_gen:should_generate(chat)
+        return { should_generate = should_generate, is_refresh = is_refresh }
+    ]])
+
+    eq(true, result.should_generate)
+    eq(true, result.is_refresh)
+end
+
+T["Title Refresh"]["should_generate returns false when max refreshes reached"] = function()
+    local result = child.lua([[              
+        local TitleGenerator = require("codecompanion._extensions.history.title_generator")
+        local refresh_gen = TitleGenerator.new({
+            auto_generate_title = true,
+            title_generation_opts = {
+                refresh_every_n_prompts = 3,
+                max_refreshes = 2
+            }
+        })
+
+        local chat = {
+            opts = { 
+                title = "Existing Title",
+                title_refresh_count = 2 -- Already at max
+            },
+            messages = {
+                { role = "user", content = "Message 1" },
+                { role = "user", content = "Message 2" },
+                { role = "user", content = "Message 3" }
+            }
+        }
+
+        local should_generate, is_refresh = refresh_gen:should_generate(chat)
+        return { should_generate = should_generate, is_refresh = is_refresh }
+    ]])
+
+    eq(false, result.should_generate)
+    eq(false, result.is_refresh)
+end
+
+T["Title Refresh"]["_count_user_messages counts only non-tagged messages with content"] = function()
+    local result = child.lua([[              
+        local chat = {
+            opts = {},
+            messages = {
+                { role = "user", content = "Valid message 1" },
+                { role = "user", content = "Valid message 2" },
+                { role = "user", content = "", opts = {} }, -- Empty content
+                { role = "user", content = "Tagged message", opts = { tag = "system" } }, -- Tagged
+                { role = "user", content = "Reference message", opts = { reference = true } }, -- Reference
+                { role = "llm", content = "Assistant response" }, -- Not user
+                { role = "user", content = "Valid message 3" }
+            }
+        }
+
+        local count = test_title_gen:_count_user_messages(chat)
+        return { count = count }
+    ]])
+
+    eq(3, result.count) -- Only the 3 valid user messages
+end
+
+T["Title Refresh"]["generate shows different feedback for refresh vs initial"] = function()
+    local result = child.lua([[              
+        local title_sequence = {}
+        local completed = false
+
+        -- Test refresh feedback
+        local chat_refresh = {
+            opts = { title = "Existing" },
+            messages = {
+                { role = "user", content = "Test message" },
+                { role = "llm", content = "Response" }
+            }
+        }
+
+        test_title_gen:generate(chat_refresh, function(title)
+            table.insert(title_sequence, title)
+            if title ~= "Refreshing title..." then
+                completed = true
+            end
+        end, true) -- is_refresh = true
+
+        vim.wait(1000, function() return completed end)
+
+        local refresh_feedback = title_sequence[1]
+
+        -- Reset for initial generation test
+        title_sequence = {}
+        completed = false
+
+        local chat_initial = {
+            opts = {},
+            messages = {
+                { role = "user", content = "Test message" }
+            }
+        }
+
+        test_title_gen:generate(chat_initial, function(title)
+            table.insert(title_sequence, title)
+            if title ~= "Deciding title..." then
+                completed = true
+            end
+        end, false) -- is_refresh = false
+
+        vim.wait(1000, function() return completed end)
+
+        local initial_feedback = title_sequence[1]
+
+        return {
+            refresh_feedback = refresh_feedback,
+            initial_feedback = initial_feedback
+        }
+    ]])
+
+    eq("Refreshing title...", result.refresh_feedback)
+    eq("Deciding title...", result.initial_feedback)
+end
+
+T["Title Refresh"]["refresh uses recent conversation context"] = function()
+    local result = child.lua([[              
+        local title_sequence = {}
+        local completed = false
+
+        -- Mock with recent conversation context
+        local chat = {
+            opts = { title = "Old Title" },
+            messages = {
+                { role = "user", content = "Old message 1" },
+                { role = "llm", content = "Old response 1" },
+                { role = "user", content = "Old message 2" },
+                { role = "llm", content = "Old response 2" },
+                { role = "user", content = "Recent message 1" },
+                { role = "llm", content = "Recent response 1" },
+                { role = "user", content = "Recent message 2" },
+                { role = "llm", content = "Recent response 2" }
+            }
+        }
+
+        test_title_gen:generate(chat, function(title)
+            table.insert(title_sequence, title)
+            if title ~= "Refreshing title..." then
+                completed = true
+            end
+        end, true) -- is_refresh = true
+
+        vim.wait(1000, function() return completed end)
+
+        local prompt = test_title_gen.last_prompt or ""
+        
+        return {
+            has_original_title = prompt:find("Old Title") ~= nil,
+            has_recent_context = prompt:find("Recent message") ~= nil,
+            has_old_context = prompt:find("Old message 1") ~= nil,
+            completed = completed
+        }
+    ]])
+
+    eq(true, result.has_original_title) -- Should include original title
+    eq(true, result.has_recent_context) -- Should include recent messages
+    eq(false, result.has_old_context) -- Should not include very old messages
+    eq(true, result.completed)
 end
 
 return T


### PR DESCRIPTION
## Description

@petobens please test out this title refresh feature you requested in #25. Once I get a green signal I will merge this.

### **What it does:**
- Chat titles now automatically refresh as conversations evolve
- Instead of staying "About ChatGPT", titles update to reflect current topic (e.g., "Lua Function Help")

### **How to test:**
```lua
-- Add this to your config
title_generation_opts = {
    refresh_every_n_prompts = 3, -- Refresh after every 3rd user message
    max_refreshes = 2,           -- Allow up to 2 refreshes per chat
}
```

### **Test scenario:**
1. Start a chat about ChatGPT → Title: "About ChatGPT" 
2. After 3rd message switch to asking about Lua → Title refreshes to "Lua Programming Help"
3. After 6th message ask about debugging → Title refreshes to "Lua Debugging Guide"
4. After 9th message → No more refreshes (max_refreshes = 2)

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/ravitemer/codecompanion-history.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make test` to ensure all tests pass
- [x] I've run `make format` to format the code
- [x] I've run `make docs` to update the vimdoc pages
