### PR TITLE
Project-Aware Chat Filtering

### DIFF
--- a/doc/codecompanion-history.txt
+++ b/doc/codecompanion-history.txt
@@ -1,4 +1,4 @@
-*codecompanion-history.txt*      For NVIM v0.8.0     Last change: 2025 June 01
+*codecompanion-history.txt*      For NVIM v0.8.0     Last change: 2025 June 10
 
 ==============================================================================
 Table of Contents                    *codecompanion-history-table-of-contents*
@@ -38,6 +38,7 @@ restoring chat sessions.
 - 🔍 Multiple picker interfaces
 - ⌛ Optional automatic chat expiration
 - ⚡ Restore chat sessions with full context and tools state
+- 🏢 **Project-aware filtering**: Filter chats by workspace/project context
 
 The following CodeCompanion features are preserved when saving and restoring
 chats:
@@ -160,6 +161,8 @@ ADD HISTORY EXTENSION TO CODECOMPANION CONFIG ~
                     dir_to_save = vim.fn.stdpath("data") .. "/codecompanion-history",
                     ---Enable detailed logging for history extension
                     enable_logging = false,
+                    ---Optional filter function to control which chats are shown when browsing
+                    chat_filter = nil, -- function(chat_data) return boolean end
                 }
             }
         }
@@ -215,6 +218,44 @@ Example configuration for title refresh:
 <
 
 
+🏢 PROJECT-AWARE CHAT FILTERING
+
+The extension supports flexible chat filtering to help you focus on relevant
+conversations:
+
+**Configurable Filtering:**
+
+>lua
+    chat_filter = function(chat_data)
+        return chat_data.cwd == vim.fn.getcwd()
+    end
+    
+    -- Recent chats only (last 7 days)
+    chat_filter = function(chat_data)
+        local seven_days_ago = os.time() - (7 * 24 * 60 * 60)
+        return chat_data.updated_at >= seven_days_ago
+    end
+<
+
+**Chat Index Data Structure:** Each chat index entry (used in filtering)
+includes the following information:
+
+>lua
+    -- ChatIndexData - lightweight metadata used for browsing and filtering
+    {
+        save_id = "1672531200",                 -- Unique chat identifier
+        title = "Debug API endpoint",           -- Chat title (auto-generated or custom)
+        cwd = "/home/user/my-project",          -- Working directory when saved
+        project_root = "/home/user/my-project", -- Detected project root
+        adapter = "openai",                     -- LLM adapter used
+        model = "gpt-4",                        -- Model name
+        updated_at = 1672531200,                -- Unix timestamp of last update
+        message_count = 15,                     -- Number of messages in chat
+        token_estimate = 3420,                  -- Estimated token count
+    }
+<
+
+
 🔧 API
 
 The history extension exports the following functions that can be accessed via
@@ -224,11 +265,14 @@ The history extension exports the following functions that can be accessed via
     -- Get the storage location for saved chats
     get_location(): string?
     
-    -- Save a chat to storage (uses last chat if none provided)
+    -- Save a chat to storage (uses last chat if none provided) 
     save_chat(chat?: CodeCompanion.Chat)
     
-    -- Get metadata for all saved chats
-    get_chats(): table<string, ChatIndexData>
+    -- Browse chats with custom filter function
+    browse_chats(filter_fn?: function(ChatIndexData): boolean)
+    
+    -- Get metadata for all saved chats with optional filtering
+    get_chats(filter_fn?: function(ChatIndexData): boolean): table<string, ChatIndexData>
     
     -- Load a specific chat by its save_id
     load_chat(save_id: string): ChatData?
@@ -241,6 +285,11 @@ Example usage:
 
 >lua
     local history = require("codecompanion").extensions.history
+    
+    -- Browse chats with project filter
+    history.browse_chats(function(chat_data)
+        return chat_data.project_root == utils.find_project_root()
+    end)
     
     -- Get all saved chats metadata
     local chats = history.get_chats()

--- a/lua/codecompanion/_extensions/history/types.lua
+++ b/lua/codecompanion/_extensions/history/types.lua
@@ -27,6 +27,7 @@
 ---@field save_chat_keymap_description? string Description for the save chat keymap (for which-key integration)
 ---@field expiration_days? number Number of days after which chats are automatically deleted (0 to disable)
 ---@field picker_keymaps? {rename?: table, delete?: table}
+---@field chat_filter? fun(chat_data: ChatIndexData): boolean Filter function for browsing chats
 
 ---@class Chat
 ---@field opts {title:string, title_refresh_count?: number, save_id: string}
@@ -61,7 +62,8 @@
 ---@field name? string
 ---@field cycle number
 ---@field title_refresh_count? number
----
+---@field cwd string Current working directory when chat was saved
+---@field project_root string Project root directory when chat was saved
 
 ---@class ChatIndexData
 ---@field title string
@@ -71,6 +73,8 @@
 ---@field adapter string
 ---@field message_count number
 ---@field token_estimate number
+---@field cwd string Current working directory when chat was saved
+---@field project_root string Project root directory when chat was saved
 
 ---@class UIHandlers
 ---@field on_preview fun(chat_data: ChatData): string[]

--- a/lua/codecompanion/_extensions/history/ui.lua
+++ b/lua/codecompanion/_extensions/history/ui.lua
@@ -157,9 +157,10 @@ local function format_chat_items(chats)
     return items
 end
 
-function UI:open_saved_chats()
+---@param filter_fn? fun(chat_data: ChatIndexData): boolean Optional filter function
+function UI:open_saved_chats(filter_fn)
     log:trace("Opening saved chats browser")
-    local index = self.storage:get_chats()
+    local index = self.storage:get_chats(filter_fn)
     if vim.tbl_isempty(index) then
         log:trace("No saved chats found")
         vim.notify("No chat history found", vim.log.levels.INFO)
@@ -189,7 +190,7 @@ function UI:open_saved_chats()
         :new(items, {
             on_open = function()
                 log:trace("Opening saved chats picker")
-                self:open_saved_chats()
+                self:open_saved_chats(filter_fn)
             end,
             ---@param chat_data ChatData
             ---@return string[] lines

--- a/lua/codecompanion/_extensions/history/utils.lua
+++ b/lua/codecompanion/_extensions/history/utils.lua
@@ -108,4 +108,25 @@ function M.fire(event, opts)
     vim.api.nvim_exec_autocmds("User", { pattern = "CodeCompanionHistory" .. event, data = opts })
 end
 
+---Find project root by looking for common project markers
+---@param start_path? string Starting path (defaults to cwd)
+---@return string project_root
+function M.find_project_root(start_path)
+    start_path = start_path or vim.fn.getcwd()
+
+    local markers = {
+        ".git",
+        "package.json",
+        "Cargo.toml",
+        "pyproject.toml",
+        "go.mod",
+        "pom.xml",
+        ".gitignore",
+        "README.md",
+    }
+
+    local root = vim.fs.root(start_path, markers)
+    return root or start_path -- fallback to start_path if no root found
+end
+
 return M

--- a/tests/test_filtering.lua
+++ b/tests/test_filtering.lua
@@ -1,0 +1,280 @@
+local h = require("tests.helpers")
+local eq, new_set = MiniTest.expect.equality, MiniTest.new_set
+local T = new_set()
+
+local child = h.new_child_neovim()
+
+T = new_set({
+    hooks = {
+        pre_case = function()
+            child.setup()
+            child.lua([[
+                -- Setup logging
+                local log = require("codecompanion._extensions.history.log")
+                log.setup_logging(false) -- Disable logging for tests
+                
+                -- Setup codecompanion with history extension
+                h = require('tests.helpers')
+                cc_h = require('tests.cc_helpers')
+                codecompanion = cc_h.setup_plugin({
+                    extensions = {
+                        history = {
+                            enabled = true,
+                            opts = {
+                                auto_generate_title = false, -- Disable to avoid async issues in tests
+                                continue_last_chat = false,
+                                delete_on_clearing_chat = false,
+                                picker = "default",
+                                enable_logging = false,
+                                dir_to_save = vim.fn.stdpath("data") .. "/codecompanion-history-filter-test-" .. os.time(),
+                            }
+                        }
+                    }
+                })
+                
+                -- Get history instance for testing
+                history_ext = require("codecompanion._extensions.history")
+                local History = history_ext.History
+                test_history = History.new({
+                    auto_generate_title = false,
+                    continue_last_chat = false,
+                    delete_on_clearing_chat = false,
+                    picker = "default",
+                    enable_logging = false,
+                    dir_to_save = vim.fn.stdpath("data") .. "/codecompanion-history-filter-test-" .. os.time(),
+                })
+            ]])
+        end,
+        post_case = function()
+            -- Clean up test directory
+            child.lua([[
+                if test_history and test_history.storage and test_history.storage.base_path then
+                    local folder = test_history.storage.base_path
+                    if vim.fn.isdirectory(folder) == 1 then
+                        vim.fn.delete(folder, "rf")
+                    end
+                end
+            ]])
+        end,
+        post_once = child.stop,
+    },
+})
+
+-- Project Root Detection Tests
+T["Project Root Detection"] = new_set()
+
+T["Project Root Detection"]["finds git project root"] = function()
+    local result = child.lua([[
+        local utils = require("codecompanion._extensions.history.utils")
+        
+        -- Create a temporary directory structure with .git
+        local test_dir = vim.fn.tempname()
+        vim.fn.mkdir(test_dir, "p")
+        vim.fn.mkdir(test_dir .. "/.git", "p")
+        vim.fn.mkdir(test_dir .. "/subdir", "p")
+        
+        -- Test from subdirectory
+        local project_root = utils.find_project_root(test_dir .. "/subdir")
+        
+        -- Cleanup
+        vim.fn.delete(test_dir, "rf")
+        
+        return {
+            project_root = project_root,
+            matches_test_dir = project_root == test_dir
+        }
+    ]])
+
+    eq(true, result.matches_test_dir)
+end
+
+T["Project Root Detection"]["falls back to provided path when no markers found"] = function()
+    local result = child.lua([[
+        local utils = require("codecompanion._extensions.history.utils")
+        
+        -- Create a temporary directory without any project markers
+        local test_dir = vim.fn.tempname()
+        vim.fn.mkdir(test_dir, "p")
+        
+        local project_root = utils.find_project_root(test_dir)
+        
+        -- Cleanup
+        vim.fn.delete(test_dir, "rf")
+        
+        return {
+            project_root = project_root,
+            matches_test_dir = project_root == test_dir
+        }
+    ]])
+
+    eq(true, result.matches_test_dir)
+end
+
+T["Project Root Detection"]["defaults to cwd when no path provided"] = function()
+    local result = child.lua([[
+        local utils = require("codecompanion._extensions.history.utils")
+        local current_cwd = vim.fn.getcwd()
+        local project_root = utils.find_project_root()
+        
+        return {
+            project_root = project_root,
+            current_cwd = current_cwd,
+            has_fallback = project_root:find(current_cwd, 1, true) ~= nil
+        }
+    ]])
+
+    eq(true, result.has_fallback)
+end
+
+-- Chat Data Enhancement Tests
+T["Chat Data Enhancement"] = new_set()
+
+T["Chat Data Enhancement"]["captures cwd and project_root on save"] = function()
+    local result = child.lua([[
+        local h = require("tests.helpers")
+        
+        -- Create a test chat
+        local chat_data = h.create_test_chat("test_context_save")
+        
+        -- Mock a chat object for saving
+        local mock_chat = {
+            opts = {
+                save_id = chat_data.save_id,
+                title = chat_data.title
+            },
+            messages = chat_data.messages,
+            settings = chat_data.settings,
+            adapter = { name = chat_data.adapter },
+            refs = {},
+            tools = { schemas = {}, in_use = {} },
+            cycle = 1
+        }
+        
+        -- Save the chat
+        test_history.storage:save_chat(mock_chat)
+        
+        -- Load it back to check context
+        local loaded_chat = test_history.storage:load_chat(chat_data.save_id)
+        local index = test_history.storage:get_chats()
+        local index_entry = index[chat_data.save_id]
+        
+        return {
+            loaded_has_cwd = loaded_chat.cwd ~= nil,
+            loaded_has_project_root = loaded_chat.project_root ~= nil,
+            index_has_cwd = index_entry.cwd ~= nil,
+            index_has_project_root = index_entry.project_root ~= nil,
+            cwd_is_string = type(loaded_chat.cwd) == "string",
+            project_root_is_string = type(loaded_chat.project_root) == "string"
+        }
+    ]])
+
+    eq(true, result.loaded_has_cwd)
+    eq(true, result.loaded_has_project_root)
+    eq(true, result.index_has_cwd)
+    eq(true, result.index_has_project_root)
+    eq(true, result.cwd_is_string)
+    eq(true, result.project_root_is_string)
+end
+
+-- Filter Function Application Tests
+T["Filter Function Application"] = new_set()
+
+T["Filter Function Application"]["get_chats with filter applies filtering"] = function()
+    local result = child.lua([[
+        local h = require("tests.helpers")
+        
+        -- Create chats with different titles
+        local chats = {
+            { id = "keep_this_1", title = "Keep This Chat 1" },
+            { id = "filter_out_1", title = "Filter Out Chat 1" },
+            { id = "keep_this_2", title = "Keep This Chat 2" },
+        }
+        
+        for _, chat in ipairs(chats) do
+            local mock_chat = {
+                opts = { save_id = chat.id, title = chat.title },
+                messages = h.create_test_chat(chat.id).messages,
+                settings = {},
+                adapter = { name = "test" },
+                refs = {}, tools = { schemas = {}, in_use = {} },
+                cycle = 1
+            }
+            test_history.storage:save_chat(mock_chat)
+        end
+        
+        -- Filter to only include chats with "Keep This" in title
+        local filtered_chats = test_history.storage:get_chats(function(chat_data)
+            return chat_data.title:find("Keep This") ~= nil
+        end)
+        
+        return {
+            filtered_count = vim.tbl_count(filtered_chats),
+            has_keep1 = filtered_chats["keep_this_1"] ~= nil,
+            has_keep2 = filtered_chats["keep_this_2"] ~= nil,
+            has_filter_out = filtered_chats["filter_out_1"] ~= nil
+        }
+    ]])
+
+    eq(2, result.filtered_count)
+    eq(true, result.has_keep1)
+    eq(true, result.has_keep2)
+    eq(false, result.has_filter_out)
+end
+
+T["Filter Function Application"]["get_last_chat with filter finds filtered last chat"] = function()
+    local result = child.lua([[
+        local h = require("tests.helpers")
+        local base_time = os.time()
+        
+        -- Create chats with different timestamps and adapters
+        local chats = {
+            { id = "old_openai", adapter = "openai", time_offset = -100 },
+            { id = "recent_test", adapter = "test", time_offset = -10 },
+            { id = "newest_openai", adapter = "openai", time_offset = -5 },
+        }
+        
+        for _, chat in ipairs(chats) do
+            local chat_data = h.create_test_chat(chat.id)
+            chat_data.updated_at = base_time + chat.time_offset
+            chat_data.adapter = chat.adapter
+            
+            local mock_chat = {
+                opts = { save_id = chat.id, title = chat_data.title },
+                messages = chat_data.messages,
+                settings = {},
+                adapter = { name = chat.adapter },
+                refs = {}, tools = { schemas = {}, in_use = {} },
+                cycle = 1
+            }
+            test_history.storage:save_chat(mock_chat)
+            
+            -- Update the saved chat's timestamp and adapter
+            local saved_chat = test_history.storage:load_chat(chat.id)
+            saved_chat.updated_at = base_time + chat.time_offset
+            saved_chat.adapter = chat.adapter
+            test_history.storage:_save_chat_to_file(saved_chat)
+            test_history.storage:_update_index_entry(saved_chat)
+        end
+        
+        -- Get last chat filtered by adapter
+        local last_openai_chat = test_history.storage:get_last_chat(function(chat_data)
+            return chat_data.adapter == "openai"
+        end)
+        
+        local last_any_chat = test_history.storage:get_last_chat()
+        
+        return {
+            last_openai_id = last_openai_chat and last_openai_chat.save_id,
+            last_any_id = last_any_chat and last_any_chat.save_id,
+            openai_is_newest_filtered = last_openai_chat and last_openai_chat.save_id == "newest_openai",
+            any_is_newest_overall = last_any_chat and last_any_chat.save_id == "newest_openai"
+        }
+    ]])
+
+    eq("newest_openai", result.last_openai_id)
+    eq("newest_openai", result.last_any_id)
+    eq(true, result.openai_is_newest_filtered)
+    eq(true, result.any_is_newest_overall)
+end
+
+return T


### PR DESCRIPTION
## Description

Implements flexible chat filtering system to address #29 - allows filtering by workspace/project context.

### ✨ Key Features
- **Automatic context capture**: Saves `cwd` and `project_root` with each chat
- **API exports**: New `browse_chats(filter_fn)` and enhanced `get_chats(filter_fn)`
- **Backward compatible**: No filter = show all chats

### 🧪 Testing
```lua
-- Example: Project-based filtering (recommended)
require("codecompanion").setup({
  extensions = {
    history = {
      enabled = true,
      opts = {
        chat_filter = function(chat_data)
          return chat_data.cwd == vim.fn.getcwd()
        end
      }
    }
  }
})

-- OR ------

-- API usage
local history = require("codecompanion").extensions.history
history.browse_chats(function(chat) return chat.cwd == vim.fn.getcwd() end)
```

**Chat Index Data Structure:**
Each chat index entry (used in filtering) includes the following information:
```lua
-- ChatIndexData - lightweight metadata used for browsing and filtering
{
    save_id = "1672531200",                 -- Unique chat identifier
    title = "Debug API endpoint",           -- Chat title (auto-generated or custom)
    cwd = "/home/user/my-project",          -- Working directory when saved
    project_root = "/home/user/my-project", -- Detected project root
    adapter = "openai",                     -- LLM adapter used
    model = "gpt-4",                        -- Model name
    updated_at = 1672531200,                -- Unix timestamp of last update
    message_count = 15,                     -- Number of messages in chat
    token_estimate = 3420,                  -- Estimated token count
}
```


### 📋 What to Test
1. Save chats in different projects/directories
2. Verify filtering works with `gh` keymap and `:CodeCompanionHistory`
3. Test `continue_last_chat` respects the filter
4. Try custom filter functions (workspace, time-based, combined)


<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

## Related Issue(s)

#29

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/ravitemer/codecompanion-history.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make test` to ensure all tests pass
- [x] I've run `make format` to format the code
- [x] I've run `make docs` to update the vimdoc pages
