### PR TITLE
feat(history): allow title modification via a decorator function

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ require("codecompanion").setup({
                 enable_logging = false,
                 ---Optional filter function to control which chats are shown when browsing
                 chat_filter = nil, -- function(chat_data) return boolean end
+                title_decorator = function(original_title)
+                    -- this can be a custom function that applies some custom
+                    -- actions to the title.
+                    return original_title
+                end
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ require("codecompanion").setup({
                     refresh_every_n_prompts = 0, -- e.g., 3 to refresh after every 3rd user prompt
                     ---Maximum number of times to refresh the title (default: 3)
                     max_refreshes = 3,
+                    format_title = function(original_title)
+                        -- this can be a custom function that applies some custom
+                        -- formatting to the title.
+                        return original_title
+                    end
                 },
                 ---On exiting and entering neovim, loads the last chat on opening chat
                 continue_last_chat = false,
@@ -124,11 +129,6 @@ require("codecompanion").setup({
                 enable_logging = false,
                 ---Optional filter function to control which chats are shown when browsing
                 chat_filter = nil, -- function(chat_data) return boolean end
-                title_decorator = function(original_title)
-                    -- this can be a custom function that applies some custom
-                    -- actions to the title.
-                    return original_title
-                end
             }
         }
     }

--- a/doc/codecompanion-history.txt
+++ b/doc/codecompanion-history.txt
@@ -1,4 +1,4 @@
-*codecompanion-history.txt*      For NVIM v0.8.0     Last change: 2025 June 24
+*codecompanion-history.txt*      For NVIM v0.8.0     Last change: 2025 July 05
 
 ==============================================================================
 Table of Contents                    *codecompanion-history-table-of-contents*
@@ -170,6 +170,11 @@ ADD HISTORY EXTENSION TO CODECOMPANION CONFIG ~
                     enable_logging = false,
                     ---Optional filter function to control which chats are shown when browsing
                     chat_filter = nil, -- function(chat_data) return boolean end
+                    title_decorator = function(original_title)
+                        -- this can be a custom function that applies some custom
+                        -- actions to the title.
+                        return original_title
+                    end
                 }
             }
         }

--- a/doc/codecompanion-history.txt
+++ b/doc/codecompanion-history.txt
@@ -159,6 +159,11 @@ ADD HISTORY EXTENSION TO CODECOMPANION CONFIG ~
                         refresh_every_n_prompts = 0, -- e.g., 3 to refresh after every 3rd user prompt
                         ---Maximum number of times to refresh the title (default: 3)
                         max_refreshes = 3,
+                        format_title = function(original_title)
+                            -- this can be a custom function that applies some custom
+                            -- formatting to the title.
+                            return original_title
+                        end
                     },
                     ---On exiting and entering neovim, loads the last chat on opening chat
                     continue_last_chat = false,
@@ -170,11 +175,6 @@ ADD HISTORY EXTENSION TO CODECOMPANION CONFIG ~
                     enable_logging = false,
                     ---Optional filter function to control which chats are shown when browsing
                     chat_filter = nil, -- function(chat_data) return boolean end
-                    title_decorator = function(original_title)
-                        -- this can be a custom function that applies some custom
-                        -- actions to the title.
-                        return original_title
-                    end
                 }
             }
         }

--- a/lua/codecompanion/_extensions/history/init.lua
+++ b/lua/codecompanion/_extensions/history/init.lua
@@ -66,6 +66,7 @@ local default_opts = {
     enable_logging = false,
     ---Filter function for browsing chats (defaults to show all chats)
     chat_filter = nil,
+    title_decorator = nil,
 }
 
 ---@type History|nil
@@ -189,6 +190,9 @@ function History:_setup_autocommands()
             local should_generate, is_refresh = self.title_generator:should_generate(chat)
             if should_generate then
                 self.title_generator:generate(chat, function(generated_title)
+                    if type(self.opts.title_decorator) == "function" then
+                        generated_title = self.opts.title_decorator(generated_title)
+                    end
                     if generated_title and generated_title ~= "" then
                         -- Always update buffer title for feedback
                         self.ui:_set_buf_title(chat.bufnr, generated_title)

--- a/lua/codecompanion/_extensions/history/init.lua
+++ b/lua/codecompanion/_extensions/history/init.lua
@@ -55,6 +55,7 @@ local default_opts = {
         refresh_every_n_prompts = 0,
         ---Maximum number of times to refresh the title (default: 3)
         max_refreshes = 3,
+        format_title = nil,
     },
     ---On exiting and entering neovim, loads the last chat on opening chat
     continue_last_chat = false,
@@ -66,7 +67,6 @@ local default_opts = {
     enable_logging = false,
     ---Filter function for browsing chats (defaults to show all chats)
     chat_filter = nil,
-    title_decorator = nil,
 }
 
 ---@type History|nil
@@ -190,8 +190,8 @@ function History:_setup_autocommands()
             local should_generate, is_refresh = self.title_generator:should_generate(chat)
             if should_generate then
                 self.title_generator:generate(chat, function(generated_title)
-                    if type(self.opts.title_decorator) == "function" then
-                        generated_title = self.opts.title_decorator(generated_title)
+                    if type(self.opts.title_generation_opts.format_title) == "function" then
+                        generated_title = self.opts.title_generation_opts.format_title(generated_title)
                     end
                     if generated_title and generated_title ~= "" then
                         -- Always update buffer title for feedback

--- a/lua/codecompanion/_extensions/history/types.lua
+++ b/lua/codecompanion/_extensions/history/types.lua
@@ -28,6 +28,7 @@
 ---@field expiration_days? number Number of days after which chats are automatically deleted (0 to disable)
 ---@field picker_keymaps? {rename?: table, delete?: table, duplicate?: table}
 ---@field chat_filter? fun(chat_data: ChatIndexData): boolean Filter function for browsing chats
+---@field title_decorator? fun(original_title: string):string a function that applies a custom transformation to the title.
 
 ---@class Chat
 ---@field opts {title:string, title_refresh_count?: number, save_id: string}

--- a/lua/codecompanion/_extensions/history/types.lua
+++ b/lua/codecompanion/_extensions/history/types.lua
@@ -11,6 +11,7 @@
 ---@field model? string? The model of the adapter to use for generation
 ---@field refresh_every_n_prompts? number Number of user prompts after which to refresh the title (0 to disable)
 ---@field max_refreshes? number Maximum number of times to refresh the title (default: 3)
+---@field format_title? fun(original_title: string):string a function that applies a custom transformation to the title.
 
 ---@class HistoryOpts
 ---@field default_buf_title? string A name for the chat buffer that tells that this is an auto saving chat
@@ -28,7 +29,6 @@
 ---@field expiration_days? number Number of days after which chats are automatically deleted (0 to disable)
 ---@field picker_keymaps? {rename?: table, delete?: table, duplicate?: table}
 ---@field chat_filter? fun(chat_data: ChatIndexData): boolean Filter function for browsing chats
----@field title_decorator? fun(original_title: string):string a function that applies a custom transformation to the title.
 
 ---@class Chat
 ---@field opts {title:string, title_refresh_count?: number, save_id: string}


### PR DESCRIPTION
## Description

Some models (especially local hosted ones like qwen3) come with thinking tags regardless of whether thinking mode is on. This mess up with the generated titles because the title will contain the `<think></think>` tag. This PR introduces a new config option, `title_decorator`, that allows the users to remove special tokens/sections like this from the title.

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/86271abc-4ed1-48f2-bb3d-eb6f61d59f9c)

With custom decorator:
```lua
title_decorator = function(s)
  return vim.trim(string.gsub(s, "<think>.*</think>", ""))
end
```
![image](https://github.com/user-attachments/assets/56a377c2-923a-437e-9b09-8728698bd746)

## Checklist

- [x] I've read the [contributing](https://github.com/ravitemer/codecompanion-history.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make test` to ensure all tests pass
- [x] I've run `make format` to format the code
- [x] I've run `make docs` to update the vimdoc pages
