### PR TITLE
fix(vectorcode): wrap logging in vim.schedule to prevent fast event context errors

### DIFF
--- a/lua/codecompanion/_extensions/history/vectorcode.lua
+++ b/lua/codecompanion/_extensions/history/vectorcode.lua
@@ -58,7 +58,9 @@ M.vectorise = check_vectorcode_wrap(function(path)
     end
     vim.system({ M.opts.vectorcode_exe, "vectorise", "--project_root", summary_dir, "--pipe", path }, {}, function(out)
         if M.opts.notify then
-            vim.notify("Indexing finished!", vim.log.levels.INFO, { title = "CodeCompanion-History" })
+            vim.schedule(function()
+                vim.notify("Indexing finished!", vim.log.levels.INFO, { title = "CodeCompanion-History" })
+            end)
         end
         local ok, _ = pcall(vim.json.decode, out.stdout)
         if not ok and out.stderr then


### PR DESCRIPTION
## Description
reproduce:

1. in codecompanion chat, run `gcs` to summarize
2. enter `@vectorcode_ls` to show the vectorcode history
3. then I got the error 
	```
	Error executing callback:
	vim/_editor.lua:0: E5560: nvim_echo must not be called in a fast event context
	stack traceback:
	        [C]: in function 'nvim_echo'
	        vim/_editor.lua: in function 'notify'
	        ...vim/lua/codecompanion/_extensions/history/vectorcode.lua:61: in function 'on_exit'
	        /usr/local/share/nvim/runtime/lua/vim/_system.lua:309: in function </usr/local/share/nvim/runtime/lua/vim/_system.lua:279>
	Press ENTER or type command to continue
	```

this fix inspire by: https://github.com/coder/claudecode.nvim/pull/54

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [ ] I've read the [contributing](https://github.com/ravitemer/codecompanion-history.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make test` to ensure all tests pass
- [ ] I've run `make format` to format the code
- [ ] I've run `make docs` to update the vimdoc pages
