### PR TITLE
Save chats to lua

### DIFF
--- a/lua/codecompanion/_extensions/history/init.lua
+++ b/lua/codecompanion/_extensions/history/init.lua
@@ -193,7 +193,7 @@ function History:_setup_autocommands()
         end),
     })
     vim.api.nvim_create_autocmd("User", {
-        pattern = "CodeCompanion*Finished",
+        pattern = { "CodeCompanionChatDone" },
         group = group,
         callback = vim.schedule_wrap(function(opts)
             if not self.opts.auto_save then

--- a/lua/codecompanion/_extensions/history/storage.lua
+++ b/lua/codecompanion/_extensions/history/storage.lua
@@ -116,9 +116,9 @@ end
 ---@param chat_data CodeCompanion.History.ChatData
 ---@return {ok: boolean, error: string|nil}
 function Storage:_save_chat_to_file(chat_data)
-    local chat_path = self.chats_dir .. "/" .. chat_data.save_id .. ".json"
+    local chat_path = self.chats_dir .. "/" .. chat_data.save_id .. ".lua"
     log:trace("Saving chat to file: %s", chat_path)
-    return utils.write_json(chat_path, chat_data)
+    return utils.write_lua(chat_path, chat_data)
 end
 
 ---@param chat_data CodeCompanion.History.ChatData
@@ -198,9 +198,9 @@ end
 ---@param id string
 ---@return CodeCompanion.History.ChatData|nil
 function Storage:load_chat(id)
-    local chat_path = self.chats_dir .. "/" .. id .. ".json"
+    local chat_path = self.chats_dir .. "/" .. id .. ".lua"
     log:trace("Loading chat from: %s", chat_path)
-    local result = utils.read_json(chat_path)
+    local result = utils.read_lua(chat_path)
 
     if not result.ok then
         if not result.error:match("does not exist") then
@@ -271,15 +271,16 @@ function Storage:save_chat(chat)
 
     log:trace("Saving chat: %s", chat.opts.save_id)
     local cwd = chat.opts.cwd or vim.fn.getcwd()
+    local timestamp = os.time()
     -- Create chat data object requiring valid types
     ---@type CodeCompanion.History.ChatData
     local chat_data = {
         save_id = chat.opts.save_id,
         title = chat.opts.title,
-        messages = chat.messages or {},
-        settings = chat.settings or {},
+        messages = vim.deepcopy(chat.messages or {}),
+        settings = vim.deepcopy(chat.settings or {}),
         adapter = chat.adapter and chat.adapter.name or "unknown",
-        updated_at = os.time(),
+        updated_at = timestamp,
         context_items = chat.context_items or {},
         schemas = (chat.tools and chat.tools.schemas) or {},
         in_use = (chat.tools and chat.tools.in_use) or {},
@@ -289,8 +290,16 @@ function Storage:save_chat(chat)
         project_root = utils.find_project_root(cwd),
     }
 
+    -- Set tool messages to be hidden when restored to prevent tool output in chat buffer
+    for _, msg in ipairs(chat_data.messages) do
+        if msg.role == "tool" or msg.tool_call_id then
+            msg.opts = msg.opts or {}
+            msg.opts.visible = false
+        end
+    end
+
     -- Save chat to file
-    local save_result = self:_save_chat_to_file(utils.remove_functions(chat_data))
+    local save_result = self:_save_chat_to_file(chat_data)
     if not save_result.ok then
         log:error("Failed to save chat: %s", save_result.error)
         return
@@ -314,7 +323,7 @@ function Storage:delete_chat(id)
 
     log:debug("Deleting chat: %s", id)
     -- Delete the chat file
-    local chat_path = self.chats_dir .. "/" .. id .. ".json"
+    local chat_path = self.chats_dir .. "/" .. id .. ".lua"
     local delete_result = utils.delete_file(chat_path)
     if not delete_result.ok then
         log:error("Failed to delete chat file: %s", delete_result.error)
@@ -394,12 +403,12 @@ function Storage:rename_chat(save_id, new_title)
     end
 
     -- Update chat data
-    local chat_path = self.chats_dir .. "/" .. save_id .. ".json"
-    local chat_result = utils.read_json(chat_path)
+    local chat_path = self.chats_dir .. "/" .. save_id .. ".lua"
+    local chat_result = utils.read_lua(chat_path)
     if chat_result.ok then
         chat_result.data.title = new_title
         chat_result.data.updated_at = os.time()
-        result = utils.write_json(chat_path, chat_result.data)
+        result = utils.write_lua(chat_path, chat_result.data)
         if not result.ok then
             log:error("Failed to update chat file with new title: %s", result.error)
             return false

--- a/lua/codecompanion/_extensions/history/utils.lua
+++ b/lua/codecompanion/_extensions/history/utils.lua
@@ -131,6 +131,39 @@ function M.fire(event, opts)
     vim.api.nvim_exec_autocmds("User", { pattern = "CodeCompanionHistory" .. event, data = opts })
 end
 
+---Write a Lua table to a .lua file using vim.inspect
+---@param file_path string Path to the file
+---@param data table Data to write
+---@return {ok: boolean, error: string|nil} Result
+function M.write_lua(file_path, data)
+    if type(data) ~= "table" then
+        return { ok = false, error = "Cannot serialize non-table data" }
+    end
+
+    -- Use vim.inspect for much simpler serialization
+    local lua_code = "return " .. vim.inspect(data)
+    return M.write_file(file_path, lua_code)
+end
+
+---Read and load a Lua table from a .lua file
+---@param file_path string Path to the file
+---@return {ok: boolean, data: table|nil, error: string|nil} Result
+function M.read_lua(file_path)
+    local Path = require("plenary.path")
+    local path = Path:new(file_path)
+
+    if not path:exists() then
+        return { ok = false, data = nil, error = "File does not exist: " .. file_path }
+    end
+
+    local success, result = pcall(dofile, file_path)
+    if not success then
+        return { ok = false, data = nil, error = "Failed to load Lua file: " .. tostring(result) }
+    end
+
+    return { ok = true, data = result, error = nil }
+end
+
 -- File I/O utility functions
 ---Read and decode a JSON file
 ---@param file_path string Path to the file


### PR DESCRIPTION
## Description

Saving chat history with tool calls resulted in several issues with encoding decoding. Storing to lua prevents the need from stripping functions and having to handle edge cases when storing.

Also using new ChatDone event makes sure chat is only saved a single time at the end of an interaction.

Tool output is hidden before saving to disk.

## Related Issue(s)
- Fixes #31
- Fixes #40

## Checklist

- [x] I've read the [contributing](https://github.com/ravitemer/codecompanion-history.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make test` to ensure all tests pass
- [x] I've run `make format` to format the code
- [x] I've run `make docs` to update the vimdoc pages
