### PR TITLE
Use markdown filetype for preview window

### DIFF
--- a/lua/codecompanion/_extensions/history/pickers/fzf-lua.lua
+++ b/lua/codecompanion/_extensions/history/pickers/fzf-lua.lua
@@ -99,7 +99,7 @@ function FzfluaPicker:browse()
                         return
                     end
                     local buf_id = previewer:get_tmp_buffer()
-                    vim.bo[buf_id].filetype = "codecompanion"
+                    vim.bo[buf_id].filetype = "markdown"
                     vim.api.nvim_buf_set_lines(buf_id, 0, -1, false, lines)
                     _:set_preview_buf(buf_id)
                 end

--- a/lua/codecompanion/_extensions/history/pickers/snacks.lua
+++ b/lua/codecompanion/_extensions/history/pickers/snacks.lua
@@ -25,7 +25,7 @@ function SnacksPicker:browse()
             end
 
             local buf_id = ctx.preview:scratch()
-            vim.bo[buf_id].filetype = "codecompanion"
+            vim.bo[buf_id].filetype = "markdown"
             vim.api.nvim_buf_set_lines(buf_id, 0, -1, false, lines)
         end,
         confirm = function(picker, _)


### PR DESCRIPTION
## Description

Originally the plugin uses the `codecompanion` file type for picker previews.

But some of us might have custom configurations for specific file types, such as using [edgy](https://github.com/folke/edgy.nvim) for window layouts, which breaks the ui.

This change sets the preview window file type to `markdown`, preventing those issues.

> [!NOTE]
> I use `fzf-lua`, I didn't test with `snacks`, but I would expect the same behavior.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

### Before

<img width="1920" height="1054" alt="Screenshot 2025-09-03 at 13 42 37" src="https://github.com/user-attachments/assets/c113d4ca-05ca-41fa-b9d2-5927aca47c85" />

### After

Changing the `ft` to `markdown`, the preview window is placed correclty.

<img width="1920" height="1054" alt="Screenshot 2025-09-03 at 13 45 30" src="https://github.com/user-attachments/assets/3ce036f2-be3a-483b-8ee9-c34589fe394a" />


## Checklist

- [x] I've read the [contributing](https://github.com/ravitemer/codecompanion-history.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make test` to ensure all tests pass
- [ ] I've run `make format` to format the code
- [ ] I've run `make docs` to update the vimdoc pages
