### PR TITLE
fix: Context messages incorrectly included in title generation

### DIFF
--- a/lua/codecompanion/_extensions/history/title_generator.lua
+++ b/lua/codecompanion/_extensions/history/title_generator.lua
@@ -103,6 +103,8 @@ function TitleGenerator:generate(chat, callback, is_refresh)
         local has_content = msg.content and vim.trim(msg.content) ~= ""
         local is_relevant_role = msg.role == config.constants.USER_ROLE or msg.role == config.constants.LLM_ROLE
         local not_tagged = not (msg.opts and (msg.opts.tag or msg.opts.reference or msg.opts.context_id))
+            and not (msg._meta and msg._meta.tag)
+            and not (msg.context and msg.context.id)
         return has_content and is_relevant_role and not_tagged
     end, chat.messages)
 
@@ -259,7 +261,7 @@ function TitleGenerator:_make_adapter_request(chat, prompt, callback)
                 if _adapter.handlers.chat_output then
                     result = _adapter.handlers.chat_output(_adapter, data)
                 else
-                   result = adapters.call_handler(_adapter, "parse_chat", data)
+                    result = adapters.call_handler(_adapter, "parse_chat", data)
                 end
                 if result and result.status then
                     if result.status == CONSTANTS.STATUS_SUCCESS then

--- a/tests/test_title_generator.lua
+++ b/tests/test_title_generator.lua
@@ -464,6 +464,57 @@ T["Content Handling"]["filters out tagged user messages"] = function()
     eq(false, result.prompt:find("Referenced message to ignore") ~= nil) -- Should not include referenced message
 end
 
+T["Content Handling"]["filters out context messages with _meta.tag and context.id"] = function()
+    local result = child.lua([[
+        local title_sequence = {}
+        local completed = false
+
+        -- Replicate the message structure CodeCompanion creates with add_context()
+        -- _meta.tag and context.id are stripped from opts by add_message() and moved
+        -- to their own top-level fields.
+        local chat = {
+            opts = {},
+            messages = {
+                {
+                    role = "user",
+                    content = "This is CLAUDE.md rules content that should be ignored for title generation",
+                    _meta = { tag = "rules" },
+                    context = { id = "<rules>CLAUDE.md</rules>" },
+                    opts = { visible = false },
+                },
+                {
+                    role = "user",
+                    content = "Do you like basketball?"
+                }
+            }
+        }
+
+        test_title_gen:generate(chat, function(title)
+            table.insert(title_sequence, title)
+            if title ~= "Deciding title..." then
+                completed = true
+            end
+        end)
+
+        vim.wait(1000, function() return completed end)
+
+        local prompt = test_title_gen.last_prompt or ""
+        return {
+            first_title = title_sequence[1],
+            final_title = title_sequence[#title_sequence],
+            completed = completed,
+            has_context = prompt:find("CLAUDE.md rules content") ~= nil,
+            has_question = prompt:find("Do you like basketball") ~= nil,
+        }
+    ]])
+
+    eq("Deciding title...", result.first_title)
+    eq("Generated Title", result.final_title)
+    eq(true, result.completed)
+    eq(false, result.has_context) -- context message must be excluded
+    eq(true, result.has_question) -- actual question must be used
+end
+
 -- Error Handling Tests
 T["Error Handling"] = new_set()
 


### PR DESCRIPTION
## Description

Context messages added via `add_context()` (rules files, attached files, buffers) were being included in title generation instead of filtered out. This caused every chat with injected context to produce a title based on that context rather than the user's actual question.

For example, a user has a CLAUDE.md loaded for every chat and is 1000 characters or more, every title is generated with that information only, and disregards the user message.

## Related Issue(s)

NA (found while debugging)

## Screenshots

All 3 titles are from the same setup and same message:

<img width="843" height="186" alt="Screenshot 2026-04-17 at 3 01 17 PM" src="https://github.com/user-attachments/assets/0ccb60c8-a7fd-4f43-bcc0-8c39b4be9e21" />

<img width="596" height="474" alt="Screenshot 2026-04-17 at 2 56 09 PM" src="https://github.com/user-attachments/assets/d5280aa4-679e-496f-9b69-05f85b7bdf27" />

## Checklist

- [x] I've read the [contributing](https://github.com/ravitemer/codecompanion-history.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make test` to ensure all tests pass
- [x] I've run `make format` to format the code
- [x] I've run `make docs` to update the vimdoc pages
